### PR TITLE
feat: Message Shortcut 기반 스레드 메시지 수집 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# 슬랙 봇 프로젝트
+# 슬랙 스레드 요약 봇
 
-TypeScript와 Node.js로 만든 슬랙 봇입니다.
+TypeScript와 Node.js로 만든 슬랙 스레드 요약 봇입니다. 
+Message Shortcut을 통해 스레드의 대화를 수집하고 요약하는 기능을 제공합니다.
 
 ## 🔧 기술 상세
 
@@ -45,6 +46,7 @@ const app = new App({
 
 **반환되는 인스턴스의 주요 메서드**:
 
+- `app.shortcut(callbackId, handler)`: Message Shortcut 등록 (우클릭 메뉴)
 - `app.command(pattern, handler)`: 슬래시 커맨드 등록
 - `app.event(eventType, handler)`: 이벤트 리스너 등록 (멘션, 메시지 등)
 - `app.message(pattern, handler)`: 메시지 이벤트 리스너
@@ -52,10 +54,10 @@ const app = new App({
 - `app.start()`: Socket Mode 시작 (포트 없음)
 - `app.start(port)`: HTTP Mode 서버 시작 (Promise 반환)
 
-### 슬래시 커맨드 핸들러
+### Message Shortcut 핸들러
 
 ```typescript
-app.command('/요약', async ({ command, ack, respond }) => {
+app.shortcut('thread_summary', async ({ shortcut, ack, respond, client, context }) => {
   // 핸들러 로직
 });
 ```
@@ -64,24 +66,24 @@ app.command('/요약', async ({ command, ack, respond }) => {
 
 ```typescript
 {
-  command: {
-    token: string,           // 검증 토큰
-    team_id: string,         // 워크스페이스 ID
-    team_domain: string,     // 워크스페이스 도메인
-    channel_id: string,      // 채널 ID
-    channel_name: string,    // 채널 이름
-    user_id: string,         // 사용자 ID
-    user_name: string,       // 사용자명
-    command: string,         // 실행된 커맨드 ('/요약')
-    text: string,           // 커맨드 뒤의 추가 텍스트
-    response_url: string,   // 지연 응답용 URL
-    trigger_id: string,     // 모달 열기용 ID
-    thread_ts?: string      // 스레드 타임스탬프 (스레드에서만 존재)
+  shortcut: MessageShortcut {
+    type: 'message_action',      // Shortcut 타입
+    callback_id: string,         // 등록된 콜백 ID ('thread_summary')
+    trigger_id: string,          // 모달 열기용 ID
+    user: { id: string },        // 실행한 사용자 정보
+    channel: { id: string },     // 채널 정보
+    message: {                   // 우클릭한 메시지 정보
+      ts: string,                // 메시지 타임스탬프 (스레드 ID로 사용)
+      user: string,              // 메시지 작성자 ID
+      text: string,              // 메시지 텍스트
+      thread_ts?: string         // 스레드 타임스탬프 (스레드 답글인 경우)
+    },
+    team: { id: string }         // 워크스페이스 정보
   },
-  ack: AckFn,           // 즉시 응답 함수
-  respond: RespondFn,       // 메시지 응답 함수
-  client: WebClient,       // Slack Web API 클라이언트
-  context: Context     // 추가 컨텍스트 정보
+  ack: AckFn,                    // 즉시 응답 함수
+  respond: RespondFn,            // 메시지 응답 함수
+  client: WebClient,             // Slack Web API 클라이언트
+  context: Context               // 봇 정보 등 컨텍스트
 }
 ```
 
@@ -145,62 +147,135 @@ await respond({
 });
 ```
 
-### 멘션 이벤트 핸들러
+### SlackMessageService 클래스
+
+스레드 메시지 수집 및 처리를 담당하는 서비스 클래스입니다.
 
 ```typescript
-app.event('app_mention', async ({ event, say }) => {
-  // 핸들러 로직
-});
+import { SlackMessageService } from './messageService';
+
+const messageService = new SlackMessageService(client);
 ```
 
-**핸들러에 전달되는 객체 구조**:
+**주요 메서드**:
+
+#### `getThreadMessages(channelId, threadTs, botUserId?)`
+
+```typescript
+const threadMessages = await messageService.getThreadMessages(
+  'C1234567890',           // 채널 ID
+  '1234567890.123456',     // 스레드 타임스탬프 (메시지 ID)
+  'U0987654321'           // 봇 사용자 ID (선택사항)
+);
+```
+
+**반환 타입 (`ThreadMessages`)**:
 
 ```typescript
 {
-  event: {
-    type: 'app_mention',         // 이벤트 타입
-    user: string,                // 멘션한 사용자 ID
-    text: string,                // 메시지 텍스트 (봇 멘션 포함)
-    ts: string,                  // 메시지 타임스탬프
-    channel: string,             // 채널 ID
-    thread_ts?: string,          // 스레드 타임스탬프 (스레드에서만 존재)
-    team: string,                // 워크스페이스 ID
-  },
-  say: SayFn,                    // 메시지 응답 함수
-  client: WebClient,             // Slack Web API 클라이언트
-  context: Context               // 추가 컨텍스트 정보
+  channelId: string,           // 채널 ID
+  threadTs: string,           // 스레드 타임스탬프
+  messageCount: number,       // 수집된 메시지 수
+  messages: ThreadMessage[],  // 메시지 배열
+  participants: string[]      // 참여자 이름 배열
 }
 ```
 
-### say() 함수
+**`ThreadMessage` 인터페이스**:
 
 ```typescript
-await say('간단한 텍스트');
-await say({
-  text: string,                    // 메시지 텍스트 (필수)
-  thread_ts?: string,             // 스레드 응답시 사용
-  blocks?: Block[],               // Block Kit UI 요소들
-  channel?: string,               // 특정 채널로 전송 (기본: 이벤트 채널)
-});
-```
-
-**텍스트 처리 예시**:
-
-```typescript
-// 멘션 텍스트에서 봇 ID 제거 후 정확한 단어 매칭
-if (event.text?.replace(/<@[^>]+>\s*/, '').trim() === '요약') {
-  // "요약" 명령 처리
+{
+  user: string,              // 사용자 ID
+  username: string,          // 사용자 표시 이름
+  text: string,             // 메시지 텍스트
+  timestamp: string,        // 원본 타임스탬프
+  formattedTime: string     // 포맷된 시간 (한국어)
 }
 ```
+
+#### `formatMessagesForSummary(threadMessages)`
+
+수집된 메시지를 요약용 텍스트로 변환합니다.
+
+```typescript
+const formattedText = messageService.formatMessagesForSummary(threadMessages);
+```
+
+**출력 예시**:
+```
+스레드 요약 요청
+참여자: 홍길동, 김철수
+메시지 수: 5개
+
+대화 내용:
+[2024. 01. 15. 14:30] 홍길동: 프로젝트 진행 어떻게 할까요?
+[2024. 01. 15. 14:32] 김철수: 먼저 요구사항 정리하면 좋겠어요
+...
+```
+
+### 메시지 필터링 로직
+
+**봇 메시지 제외**:
+1. `message.subtype`이 있는 메시지 (다른 봇, 시스템 메시지)
+2. `message.user === botUserId`인 메시지 (현재 봇)
+3. 요약 요청 메시지 (`@봇 요약` 형태)
+
+**사용자 정보 조회**:
+- `client.users.info()` API 사용
+- 실제 이름 또는 표시 이름 우선 사용
+- 조회 실패시 사용자 ID 사용
+
+## 🚀 주요 기능
+
+### Message Shortcut 방식 스레드 요약
+1. **사용법**: 채널 메시지 우클릭 → "스레드 요약하기" 선택
+2. **동작**: 해당 메시지에 달린 모든 스레드 답글 수집 및 분석
+3. **응답**: ephemeral 메시지로 요청자에게만 결과 표시
+
+### 스마트 메시지 필터링
+- 봇 메시지 자동 제외 (시스템 메시지, 다른 봇, 현재 봇)
+- 요약 요청 메시지 제외
+- 실제 사용자 대화만 수집
+
+### 사용자 친화적 인터페이스
+- 한국어 인터페이스
+- 직관적인 우클릭 메뉴
+- 개인적인 결과 표시 (채널 방해 없음)
 
 ## 📋 현재 구현 상태
 
-- ✅ 기본 Slack Bolt 앱 설정
-- ✅ Socket Mode와 HTTP Mode 자동 감지 및 설정
-- ✅ `/요약` 슬래시 커맨드 등록
-- ✅ 멘션 이벤트 핸들러 구현 (`@봇 요약` 감지)
-- ✅ 스레드 감지 로직 (`thread_ts` 존재 여부 확인)
-- ✅ 정확한 "요약" 단어 매칭 (멘션 ID 제거 후 비교)
-- ✅ 한국어 에러 메시지
-- ⏳ 슬랙 앱 생성 및 토큰 설정 (다음 단계)
-- ⏳ 실제 요약 기능 구현
+- ✅ **기본 Slack Bolt 앱 설정**
+- ✅ **Socket Mode와 HTTP Mode 자동 감지 및 설정**
+- ✅ **Message Shortcut 등록** (`thread_summary`)
+- ✅ **SlackMessageService 클래스 구현**
+  - ✅ 스레드 메시지 수집 (`conversations.replies` API)
+  - ✅ 사용자 정보 조회 (`users.info` API)
+  - ✅ 메시지 필터링 및 포맷팅
+  - ✅ 타임스탬프 한국어 변환
+- ✅ **TypeScript 타입 안전성**
+  - ✅ `MessageShortcut` 타입 적용
+  - ✅ 커스텀 인터페이스 정의 (`ThreadMessage`, `ThreadMessages`)
+- ✅ **에러 핸들링 및 사용자 피드백**
+- ✅ **한국어 메시지 및 에러 처리**
+- ⏳ **AI 요약 기능 연동** (다음 단계)
+- ⏳ **결과 저장 기능** (Notion, 파일 등)
+
+## 🛠️ 설정 방법
+
+### 1. Slack 앱 설정
+1. **Interactivity & Shortcuts** → **Message Shortcuts** 추가:
+   - Name: `스레드 요약하기`
+   - Callback ID: `thread_summary`
+
+### 2. 필요한 권한
+- `chat:write`: 메시지 전송
+- `channels:history`: 채널 메시지 읽기
+- `groups:history`: 비공개 채널 메시지 읽기
+- `users:read`: 사용자 정보 조회
+
+### 3. 환경 변수
+```bash
+SLACK_BOT_TOKEN=xoxb-...     # 봇 토큰
+SLACK_SIGNING_SECRET=...     # 서명 검증 키
+SLACK_SOCKET_TOKEN=xapp-...  # Socket Mode 토큰 (선택사항)
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { App } from '@slack/bolt';
 import dotenv from 'dotenv';
-import { handleSummaryCommand, handleMentionSummary } from './slack/commands';
+import { handleThreadSummaryAction } from './slack/commands';
 
 dotenv.config();
 
@@ -36,11 +36,9 @@ const app = new App({
   ...(isSocketModeEnabled && { appToken: SLACK_SOCKET_TOKEN }),
 });
 
-// 슬래시 커맨드 등록
-app.command('/요약', handleSummaryCommand);
+// Message Shortcut 등록 (우클릭 메뉴)
+app.shortcut('thread_summary', handleThreadSummaryAction);
 
-// 멘션 이벤트 리스너 (스레드에서 봇 멘션 + "요약" 키워드 감지)
-app.event('app_mention', handleMentionSummary);
 
 // 앱 시작
 (async () => {

--- a/src/slack/messageService.ts
+++ b/src/slack/messageService.ts
@@ -1,0 +1,179 @@
+export interface ThreadMessage {
+  user: string;
+  username: string;
+  text: string;
+  timestamp: string;
+  formattedTime: string;
+}
+
+export interface ThreadMessages {
+  channelId: string;
+  threadTs: string;
+  messageCount: number;
+  messages: ThreadMessage[];
+  participants: string[];
+}
+
+// 필요한 클라이언트 메서드만 정의
+interface SlackClient {
+  conversations: {
+    replies: (params: { channel: string; ts: string; inclusive?: boolean }) => Promise<{
+      messages?: Array<{
+        user?: string;
+        text?: string;
+        ts?: string;
+        subtype?: string;
+      }>;
+    }>;
+  };
+  users: {
+    info: (params: { user: string }) => Promise<{
+      user?: {
+        real_name?: string;
+        profile?: {
+          display_name?: string;
+        };
+      };
+    }>;
+  };
+}
+
+export class SlackMessageService {
+  private client: SlackClient;
+
+  constructor(client: SlackClient) {
+    this.client = client;
+  }
+
+  /**
+   * 스레드의 모든 메시지를 가져와서 요약 가능한 형태로 변환
+   */
+  async getThreadMessages(
+    channelId: string,
+    threadTs: string,
+    botUserId?: string
+  ): Promise<ThreadMessages> {
+    try {
+      // 스레드의 모든 메시지 가져오기
+      const threadResponse = await this.client.conversations.replies({
+        channel: channelId,
+        ts: threadTs,
+        inclusive: true, // 스레드 시작 메시지도 포함
+      });
+
+      if (!threadResponse.messages) {
+        throw new Error('스레드 메시지를 가져올 수 없습니다.');
+      }
+
+      const messages: ThreadMessage[] = [];
+      const participants = new Set<string>();
+
+      for (const message of threadResponse.messages) {
+        if (!message.user || !message.text || message.subtype) {
+          continue; // 봇 메시지나 시스템 메시지 제외
+        }
+
+        // 봇이 보낸 메시지 제외
+        if (botUserId && message.user === botUserId) {
+          continue;
+        }
+
+        // 봇 멘션이 포함된 요약 요청 메시지 제외
+        if (this.isSummaryRequestMessage(message.text, botUserId)) {
+          continue;
+        }
+
+        // 사용자 정보 가져오기
+        const userInfo = await this.getUserInfo(message.user);
+        const username = userInfo?.real_name || userInfo?.profile?.display_name || message.user;
+
+        // 타임스탬프를 읽기 쉬운 형태로 변환
+        const timestamp = message.ts || '';
+        const formattedTime = this.formatTimestamp(timestamp);
+
+        messages.push({
+          user: message.user,
+          username,
+          text: message.text,
+          timestamp,
+          formattedTime,
+        });
+
+        participants.add(username);
+      }
+
+      return {
+        channelId,
+        threadTs,
+        messageCount: messages.length,
+        messages,
+        participants: Array.from(participants),
+      };
+    } catch (error) {
+      console.error('스레드 메시지 수집 실패:', error);
+      throw new Error('스레드 메시지를 수집하는 중 오류가 발생했습니다.');
+    }
+  }
+
+  /**
+   * 사용자 정보 가져오기 (캐시 적용 가능)
+   */
+  private async getUserInfo(userId: string) {
+    try {
+      const userResponse = await this.client.users.info({ user: userId });
+      return userResponse.user || null;
+    } catch (error) {
+      console.warn(`사용자 정보 조회 실패 (${userId}):`, error);
+      return null;
+    }
+  }
+
+  /**
+   * 타임스탬프를 읽기 쉬운 형태로 변환
+   */
+  private formatTimestamp(timestamp: string): string {
+    const date = new Date(parseFloat(timestamp) * 1000);
+    return date.toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  /**
+   * 요약 요청 메시지인지 확인
+   */
+  private isSummaryRequestMessage(text: string, botUserId?: string): boolean {
+    // 봇 멘션이 포함되고 "요약" 키워드가 있는 경우
+    if (botUserId && text.includes(`<@${botUserId}>`) && text.includes('요약')) {
+      return true;
+    }
+
+    // 단순히 "요약"만 있는 메시지 (봇 멘션 없이)
+    if (text.trim() === '요약') {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * 메시지들을 요약을 위한 텍스트 형태로 변환
+   */
+  formatMessagesForSummary(threadMessages: ThreadMessages): string {
+    const { messages, participants } = threadMessages;
+
+    let formattedText = `스레드 요약 요청\n`;
+    formattedText += `참여자: ${participants.join(', ')}\n`;
+    formattedText += `메시지 수: ${messages.length}개\n\n`;
+    formattedText += `대화 내용:\n`;
+
+    for (const message of messages) {
+      formattedText += `[${message.formattedTime}] ${message.username}: ${message.text}\n`;
+    }
+
+    return formattedText;
+  }
+}


### PR DESCRIPTION
## 📋 변경사항

  ### 구현된 기능
  - Message Shortcut (우클릭 메뉴) 방식으로 스레드 요약 시스템 개편
  - SlackMessageService 클래스 기반 실제 스레드 메시지 수집 기능 구현
  - 스마트 메시지 필터링 (봇 메시지, 시스템 메시지 자동 제외)
  -  ephemeral 응답으로 개인적 결과 표시 (채널 방해 없음)

  ### 기능 상세
  - **Message Shortcut**: 채널 메시지 우클릭 → "스레드 요약하기" 선택으로 직관적 사용
  - **실제 메시지 수집**: conversations.replies API로 스레드 전체 메시지 수집
  - **사용자 정보 조회**: users.info API로 실제 이름/표시 이름 획득
  - **스마트 필터링**: message.subtype 있는 메시지 제외 (다른 봇, 시스템 메시지), message.user === botUserId 메시지 제외 (현재 봇), 요약 요청 메시지 자동 제외
  - **타임스탬프 변환**: Unix 타임스탬프를 한국어 시간 형식으로 변환


  ## 🧪 테스트 방법
  1. Slack 앱 설정에서 Message Shortcuts 추가:
    - Name: 스레드 요약하기
    - Callback ID: thread_summary
  2. 필요 권한 확인: chat:write, channels:history, groups:history, users:read
  3. pnpm start로 봇 실행
  4. 스레드가 있는 채널 메시지 우클릭 → "스레드 요약하기" 선택
  5. ephemeral 메시지로 수집 정보 확인 (참여자, 메시지 수 등)
  6. 스레드가 없는 메시지에서 시도 시 안내 메시지 확인